### PR TITLE
Fix performance issues with large projects

### DIFF
--- a/nx-completion.plugin.zsh
+++ b/nx-completion.plugin.zsh
@@ -31,15 +31,11 @@ _check_workspace_def() {
     fi
   done
 
-  # For performance reasons, we cache the workspace definition file
-  # in a tmp file. This file is generated only once per workspace.
+  # To get all workspace projects and targets nx graph needs to be called to store the
+  # data in a file.
   local cwd_id=$(echo $PWD | md5sum | awk '{print $1}')
   tmp_cached_def="/tmp/nx-completion-$cwd_id.json"
-  
-  if [[ ! -f $tmp_cached_def ]]; then
-    nx graph --file="$tmp_cached_def" > /dev/null && ret=0
-  fi
-  
+  nx graph --file="$tmp_cached_def" > /dev/null && ret=0
   return ret
 }
 

--- a/nx-completion.plugin.zsh
+++ b/nx-completion.plugin.zsh
@@ -57,7 +57,7 @@ _workspace_def() {
 _workspace_projects() {
   integer ret=1
   local def=$(_workspace_def)
-  local -a projects=($(<$def | jq -r '.graph.nodes | keys[]'))
+  local -a projects=($(<$def | jq -r '.graph.nodes[] | .name'))
   echo $projects && ret=0
   return ret
 }
@@ -79,16 +79,7 @@ _list_targets() {
   [[ $PREFIX = -* ]] && return 1
   integer ret=1
   local def=$(_workspace_def)
-  local -a projects=($(_workspace_projects))
-  local -a targets
-
-  # Collect targets for each project.
-  for p in $projects; do
-    local -a executors=($(<$def | jq -r ".graph.nodes.\"$p\".data.targets | keys[]"))
-    for e in $executors; do
-      targets+=("$p\:$e")
-    done
-  done
+  local -a targets=($(<$def | jq -r '.graph.nodes[] | { name: .name, target: (.data.targets | keys[]) } | .name + "\\:" + .target'))
 
   _describe -t project-targets 'Project targets' targets && ret=0
   return ret


### PR DESCRIPTION
In a bigger workspace (more than 300 targets across more than 80 projects) the "nx run " auto-complete was terribly slow (~15s-20s on an M1)

With this PR the collection of the targets is done with a single jq-query instead of making a separate query for each project which gives a result nearly instantly.

Furthermore I had to remove the "caching" of the workspace graph to be able to pickup changes done to the workspace.json.

This caching could be reintroduced again by hashing the actual workspace.json together with "sub-jsons" - but this was out of scope now. 
  