### PR TITLE
md5 Cache - add MacOS support

### DIFF
--- a/nx-completion.plugin.zsh
+++ b/nx-completion.plugin.zsh
@@ -33,7 +33,7 @@ _check_workspace_def() {
 
   # To get all workspace projects and targets nx graph needs to be called to store the
   # data in a file.
-  local cwd_id=$(echo $PWD | md5 -r | awk '{print $1}')
+  local cwd_id=$(echo $PWD | (command -v md5sum &> /dev/null && md5sum || md5 -r) | awk '{print $1}')
   tmp_cached_def="/tmp/nx-completion-$cwd_id.json"
   nx graph --file="$tmp_cached_def" > /dev/null && ret=0
   return ret

--- a/nx-completion.plugin.zsh
+++ b/nx-completion.plugin.zsh
@@ -33,7 +33,7 @@ _check_workspace_def() {
 
   # To get all workspace projects and targets nx graph needs to be called to store the
   # data in a file.
-  local cwd_id=$(echo $PWD | md5sum | awk '{print $1}')
+  local cwd_id=$(echo $PWD | md5 -r | awk '{print $1}')
   tmp_cached_def="/tmp/nx-completion-$cwd_id.json"
   nx graph --file="$tmp_cached_def" > /dev/null && ret=0
   return ret


### PR DESCRIPTION
## Context
`md5sum` is not natively supported by MacOS. To reduce the count of 3th party dependencies i switch to a native cli.

## Impacted change
This PR switch to `md5` cli instead of `md5sum` when `md5sum` is not a known command in the system 

## Original Issue
Fix #19 