### PR TITLE
fix: _nx_workspace_targets properly backport

### DIFF
--- a/nx-completion.plugin.zsh
+++ b/nx-completion.plugin.zsh
@@ -66,9 +66,8 @@ _workspace_projects() {
 # Collect workspace targets
 _nx_workspace_targets() {
   integer ret=1
-  if _workspace_def; then
-    jq -r '[.graph.nodes[] | .data.targets | keys[]] | unique[] | if test(":") then . | gsub(":"; "\\:") else . end' $_nx_tmp_cached_def && ret=0
-  fi
+  local def=$(_workspace_def)
+  jq -r '[.graph.nodes[] | .data.targets | keys[]] | unique[] | if test(":") then . | gsub(":"; "\\:") else . end' $def && ret=0
   return ret
 }
 


### PR DESCRIPTION
since i originally wrote _nx_workspace_targets in my [`cleanup`](https://github.com/forivall/nx-completion/tree/cleanup?rgh-link-date=2023-03-04T09%3A14%3A12Z) cleanup branch, it caused the [`command not found` issue](https://github.com/jscutlery/nx-completion/commit/c43a9c729cf3624f48eba86d0d5f1d8e74fbe0f2), as my cleanup branch changes how functions are called in an attempt to improve performance (not sure if that's necessary, but that's besides the point).

While your effort to fix it was valiant, it's not quite right 😅 so this is the correct fix.